### PR TITLE
Precompile

### DIFF
--- a/src/TerminalMenus.jl
+++ b/src/TerminalMenus.jl
@@ -1,4 +1,12 @@
+__precompile__()
 module TerminalMenus
+
+terminal = nothing  # The user terminal
+
+function __init__()
+    global terminal
+    terminal = Base.Terminals.TTYTerminal(get(ENV, "TERM", is_windows() ? "" : "dumb"), STDIN, STDOUT, STDERR)
+end
 
 include("util.jl")
 include("config.jl")

--- a/src/util.jl
+++ b/src/util.jl
@@ -10,9 +10,6 @@
     PAGE_UP,
     PAGE_DOWN)
 
-# The user terminal
-terminal = Base.Terminals.TTYTerminal(get(ENV, "TERM", @static is_windows() ? "" : "dumb"), STDIN, STDOUT, STDERR)
-
 # Enable raw mode. Allows us to process keyboard inputs directly.
 enableRawMode() = Base.Terminals.raw!(terminal, true)
 


### PR DESCRIPTION
After enabling precompilation in `PkgTemplates`, I found that `TerminalMenus` no longer worked consistently, and I came to the conclusion that this module is not safe to precompile. This change appears to fix that problem, and now precompiled modules can have `TerminalMenus` as a dependency.