### PR TITLE
Allow specifying the terminal in `request`

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -11,9 +11,9 @@
     PAGE_DOWN)
 
 # Enable raw mode. Allows us to process keyboard inputs directly.
-function enableRawMode()
+function enableRawMode(term)
     try
-        Base.Terminals.raw!(terminal, true)
+        Base.Terminals.raw!(term, true)
         return true
     catch Exception
         warn("TerminalMenus: Unable to enter raw mode")
@@ -22,9 +22,9 @@ function enableRawMode()
 end
 
 # Disable raw mode. Give control back to Julia REPL if interactive session.
-function disableRawMode()
+function disableRawMode(term)
     try
-        Base.Terminals.raw!(terminal, false)
+        Base.Terminals.raw!(term, false)
         return true
     catch Exception
         warn("TerminalMenus: Unable to disable raw mode")
@@ -34,18 +34,18 @@ end
 
 
 # Reads a single byte from STDIN
-readNextChar() = Char(read(STDIN,1)[1])
+readNextChar(stream::IO=STDIN) = Char(read(stream,1)[1])
 
 # Read the next key from STDIN. It is also able to read several bytes for
 #   escaped keys such as the arrow keys, home/end keys, etc.
 # Escaped keys are returned using the `Key` enum.
-function readKey() ::UInt32
-    c = readNextChar()
+function readKey(stream::IO=STDIN) ::UInt32
+    c = readNextChar(stream)
 
 	# Escape characters
 	if c == '\x1b'
-        STDIN.buffer.size < 2 && return '\x1b'
-        esc_a = readNextChar()
+        stream.buffer.size < 2 && return '\x1b'
+        esc_a = readNextChar(stream)
 
         if esc_a == 'v'  # M-v
             return PAGE_UP
@@ -55,13 +55,13 @@ function readKey() ::UInt32
             return END_KEY
         end
 
-        STDIN.buffer.size < 3 && return '\x1b'
-        esc_b = readNextChar()
+        stream.buffer.size < 3 && return '\x1b'
+        esc_b = readNextChar(stream)
 
 		if esc_a == '['
 			if esc_b >= '0' && esc_b <= '9'
-				STDIN.buffer.size < 4 && return '\x1b'
-                esc_c = readNextChar()
+				stream.buffer.size < 4 && return '\x1b'
+                esc_c = readNextChar(stream)
 
 				if esc_c == '~'
 					if esc_b == '1'


### PR DESCRIPTION
While a good default sometimes I want to display a menu on a terminal
other than the main one (e.g. if I let somebody connect to my app via
ssh or for a multi-terminal application). Add an optional first argument
to allow specifying the terminal.