### PR TITLE
Display exceptions

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -15,8 +15,8 @@ function enableRawMode(term)
     try
         Base.Terminals.raw!(term, true)
         return true
-    catch Exception
-        warn("TerminalMenus: Unable to enter raw mode")
+    catch err
+        warn("TerminalMenus: Unable to enter raw mode: $err")
     end
     return false
 end
@@ -26,8 +26,8 @@ function disableRawMode(term)
     try
         Base.Terminals.raw!(term, false)
         return true
-    catch Exception
-        warn("TerminalMenus: Unable to disable raw mode")
+    catch err
+        warn("TerminalMenus: Unable to disable raw mode: $err")
     end
     return false
 end


### PR DESCRIPTION
Not much to see here, I just noticed that the exceptions were being caught in what I assume is Python style (`catch Exception` assigns to `Exception` instead of just catching all exceptions) so I changed it such that it doesn't override the existing binding, and  added it to the warning message.