### PR TITLE
Have ^C throw InterruptException

### DIFF
--- a/src/AbstractMenu.jl
+++ b/src/AbstractMenu.jl
@@ -172,9 +172,11 @@ function request(term::Base.Terminals.TTYTerminal, m::AbstractMenu)
             elseif c == 13 # <enter>
                 # will break if pick returns true
                 pick(m, cursor) && break
-            elseif c == UInt32('q') || c == 3 # ctrl-c (cancel)
+            elseif c == UInt32('q')
                 cancel(m)
                 break
+            elseif c == 3 # ctrl-c
+                throw(InterruptException())
             else
                 # will break if keypress returns true
                 keypress(m, c) && break


### PR DESCRIPTION
In general ^C throws InterruptException. The only reason this doesn't
happen in TerminalMenus is because we enable raw mode which makes ^C
just another key sequence. I think it is more coherent to make this
throw an InterruptException as it would in non-raw parts of code.
If the calling code wants to handle this, it can catch the exception.

Fixes https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/35