### PR TITLE
advance cursor after selecting item in multi-select menu

### DIFF
--- a/src/MultiSelectMenu.jl
+++ b/src/MultiSelectMenu.jl
@@ -9,7 +9,7 @@ A menu that allows a user to select a multiple options from a list.
 ```julia
 julia> request(MultiSelectMenu(options))
 Select the fruits you like:
-[press: d=done, a=all, n=none]
+[press: d=done, a=all, n=none, <enter>=select]
    [ ] apple
  > [X] orange
    [X] grape
@@ -82,7 +82,7 @@ function pick(menu::MultiSelectMenu, cursor::Int)
         push!(menu.selected, cursor)
     end
 
-    return false #break out of the menu
+    return false #don't break out of the menu
 end
 
 function writeLine(buf::IOBuffer, menu::MultiSelectMenu, idx::Int, cursor::Bool, term_width::Int)

--- a/test/multiselect_menu.jl
+++ b/test/multiselect_menu.jl
@@ -33,4 +33,4 @@ TerminalMenus.writeLine(buf, multi_menu, 1, true, term_width)
 
 # Test SDTIN
 multi_menu = MultiSelectMenu(string.(1:10))
-@test simulateInput(Set([1,2]), multi_menu, :enter, :down, :enter, 'd')
+@test simulateInput(Set([1,2]), multi_menu, :enter, :enter, 'd')


### PR DESCRIPTION
...and document that the Enter key is used for selection.

fixes https://github.com/nick-paul/TerminalMenus.jl/issues/17